### PR TITLE
added all constants from documentation

### DIFF
--- a/constants.cs
+++ b/constants.cs
@@ -6,5 +6,70 @@ public static class Constants {
 
 	// All token IDs (add more as we come across them)
 	public enum TOKENS {
+		// Reserved Words
+		AND,			// "and"
+		BEGIN,			// "begin"
+		BOOLEAN,		// "boolean"
+		DIV,			// "div"
+		DO, 			// "do"
+		DOWNTO,			// "downto"
+		ELSE,			// "else"
+		END,			// "end"
+		FALSE,			// "False"
+		FIXED,			// "fixed"
+		FLOAT,			// "float"
+		FOR,			// "for"
+		FUNCTION,		// "function"
+		IF,				// "if"
+		INTEGER,		// "integer"
+		MOD,			// "mod"
+		NOT,			// "not"
+		OR,				// "or"
+		PROCEDURE,		// "procedure"
+		PROGRAM,		// "program"
+		READ,			// "read"
+		REPEAT,			// "repeat"
+		STRING,			// "string"
+		THEN,			// "then"
+		TRUE,			// "true"
+		TO,				// "to"
+		TYPE,			// "type"
+		UNTIL,			// "until"
+		VAR,			// "var"
+		WHILE,			// "while"
+		WRITE,			// "write"
+		WRITELN,		// "writeln"
+
+		// Identifiers and Literals
+		IDENTIFIER,		// (letter | "_"(letter | digit)){["_"](letter | digit)}
+		INTEGER_LIT,	// digit{digit}
+		FIXED_LIT,		// digit{digit} "." digit{digit}
+		FLOAT_LIT,		// (digit{digit} | digit{digit} "." digit{digit}) ("e"|"E")["+"|"-"]digit{digit}
+		STRING_LIT,		// "'" {"''" | AnyCharacterExceptApostropheOrEOL} "'"
+
+		// Single String Tokens
+		ASSIGN,			// ":="
+		COLON,			// ":"
+		COMMA,			// ","
+		EQUAL,			// "="
+		FLOAT_DIVIDE,	// "/"
+		GEQUAL,			// ">="
+		GTHAN,			// ">"
+		LEQUAL,			// "<="
+		LPAREN,			// "("
+		LTHAN,			// "<"
+		MINUS,			// "-"
+		NEQUAL,			// "<>"
+		PERIOD,			// "."
+		PLUS,			// "+"
+		RPAREN,			// ")"
+		SCOLON,			// ";"
+		TIMES,			// "*"
+
+		// Special Tokens
+		EOF,			// end-of-file character
+		RUN_COMMENT,	// run-on comment error
+		RUN_STRING,		// run-on string error
+		ERROR,			// token for other scan errors
 	};
 }


### PR DESCRIPTION
Ticket #4 - Populate tokens

Added:
- Reserved words
- Identifiers and Literals
- Single String Tokens
- Special Tokens

While most of these are not needed yet, I just went ahead and added every token from the documentation as I figured we may use them eventually. It's possible we'll need to refactor these later.
