### PR TITLE
added generic .gitignore from octocat, does include .exe files as well

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,41 @@
+# Generic .gitignore from octocat/.gitignore
+# https://gist.github.com/octocat/9257657
+
+# Compiled source #
+###################
+*.com
+*.class
+*.dll
+*.exe
+*.o
+*.so
+ 
+# Packages #
+############
+# it's better to unpack these files and commit the raw source
+# git has its own built in compression methods
+ *.7z
+ *.dmg
+ *.gz
+ *.iso
+ *.jar
+ *.rar
+ *.tar
+ *.zip
+  
+# Logs and databases #
+######################
+  *.log
+  *.sql
+  *.sqlite
+   
+# OS generated files #
+######################
+   .DS_Store
+   .DS_Store?
+   ._*
+   .Spotlight-V100
+   .Trashes
+   ehthumbs.db
+   Thumbs.db
+


### PR DESCRIPTION
Generic .gitignore to ignore any and all files that should not be pushed to github. I figured this is better than just a .exe to cover all cases. Credit goes to octocat: https://gist.github.com/octocat/9257657
