### PR TITLE
Output refactor

### DIFF
--- a/constants.cs
+++ b/constants.cs
@@ -73,7 +73,13 @@ public enum TOKENS {
 public static class Constants {
     // Generic string messages
     public const string USAGE_HELP = "Usage: mono YµP.exe <µPascal filename> <output filename>";
-    public const string TOKEN_TABLE_HEADER = "token\t\tlexeme\tline\tcolumn";
+    public const string TOKEN_TABLE_HEADER = String.Format(
+        "{0,-12}{1,8}{2,8}\t{3}",
+        "TOKEN",
+        "LINE",
+        "COLUMN",
+        "LEXEME"
+    );
 
     // Error messages
     public const string ERROR_FILE_FORMAT = "ERROR: File format does not conform to format: <filename>.mp; ";

--- a/constants.cs
+++ b/constants.cs
@@ -73,13 +73,7 @@ public enum TOKENS {
 public static class Constants {
     // Generic string messages
     public const string USAGE_HELP = "Usage: mono YµP.exe <µPascal filename> <output filename>";
-    public const string TOKEN_TABLE_HEADER = String.Format(
-        "{0,-12}{1,8}{2,8}\t{3}",
-        "TOKEN",
-        "LINE",
-        "COLUMN",
-        "LEXEME"
-    );
+    public const string TOKEN_TABLE_HEADER_FORMAT = "{0,-12}{1,8}{2,8}\t{3}";
 
     // Error messages
     public const string ERROR_FILE_FORMAT = "ERROR: File format does not conform to format: <filename>.mp; ";

--- a/main.cs
+++ b/main.cs
@@ -10,7 +10,9 @@ public class Driver {
         }
         Scanner scanner = new Scanner();
         List<Token> tokens = scanner.initializeScanner(args[0]);
-        Console.WriteLine(Constants.TOKEN_TABLE_HEADER);
+        Console.WriteLine(Constants.TOKEN_TABLE_HEADER_FORMAT,
+            "TOKEN", "LINE", "COLUMN", "LEXEME"
+        );
         foreach(Token token in tokens){
             Console.WriteLine(
                 "{0,-12}{1,8}{2,8}\t{3}",

--- a/main.cs
+++ b/main.cs
@@ -13,10 +13,12 @@ public class Driver {
         Console.WriteLine(Constants.TOKEN_TABLE_HEADER);
         foreach(Token token in tokens){
             Console.WriteLine(
-                token.Type.ToString() + "\t" +
-                token.Lexeme + "\t" +
-                token.Line + "\t" +
-                token.Column);
+                "{0,-12}{1,8}{2,8}\t{3}",
+                token.Type.ToString(),
+                token.Line,
+                token.Column,
+                token.Lexeme
+            );
         }
     }
 }


### PR DESCRIPTION
Small change to make the output pretty. The -12 forces 12 spaces starting at the left to be reserved for token name, even though only one of our tokens is actually that long. Then 8 (right-aligned) spaces each for column and line number (mostly for the headings moreso than the actual values). Then a tab, and the identifier begins left aligned and continues.
