### PR TITLE
fixed comment handling

### DIFF
--- a/scanner.cs
+++ b/scanner.cs
@@ -74,7 +74,6 @@ public partial class Scanner {
                     // Look for comments
                     else if(__bytes[__curByte] == '{') {
                         commentFlag = true;
-                        __line++;
                         __curByte++;
                         continue;
                     }

--- a/scanner.cs
+++ b/scanner.cs
@@ -40,7 +40,7 @@ public partial class Scanner {
 
                 // Caching length to save memory
                 int length = __bytes.Length;
-                if(__bytes[length-1] != '\n'){
+                if(__bytes[length - 1] != '\n'){
                     throw new Exception(Constants.ERROR_NO_NEWLINE);
                 }
 
@@ -51,28 +51,30 @@ public partial class Scanner {
 
                 // Loop until EOF, ignoring whitespace
                 while(__curByte < length){
-                    // Handle comments
-                    if(__bytes[__curByte] == '{') {
-                        // Check for run on comment error
-                        if(commentFlag) {
-                            __tokens.Add(new Token("{", TOKENS.RUN_COMMENT, __column, __line));
+                    // In comment mode, ignore everything
+                    if(commentFlag) {
+                        if(__bytes[__curByte] == '\n') {
+                            __line++;
+                            __column = 1;
                         }
-                        commentFlag = true;
-                        __line++;
-                        __curByte++;
-                        continue;
-                    }
-                    // In comment mode, skip everything, look for end of comment
-                    else if(commentFlag) {
-                        if(__bytes[__curByte] == '}') {
+                        // Look for end of comments
+                        else if (__bytes[__curByte] == '}') {
                             commentFlag = false;
                             __column++;
-                        } else if(__bytes[__curByte] == '\n') {
-                            __line++;
-                            __column = 0;
+                        }
+                        // Handle run on comment error
+                        else if (__curByte == __bytes.Length - 1) {
+                            __tokens.Add(new Token("{", TOKENS.RUN_COMMENT, __column, __line));
                         } else {
                             __column++;
                         }
+                        __curByte++;
+                        continue;
+                    }
+                    // Look for comments
+                    else if(__bytes[__curByte] == '{') {
+                        commentFlag = true;
+                        __line++;
                         __curByte++;
                         continue;
                     }
@@ -80,7 +82,7 @@ public partial class Scanner {
                     else if(ws.Contains("" + __bytes[__curByte])) {
                         if(__bytes[__curByte] == '\n'){
                             __line++;
-                            __column = 0;
+                            __column = 1;
                         } else if(__bytes[__curByte] == ' ') {
                             __column++;
                         }

--- a/testProgs/parseError.mp
+++ b/testProgs/parseError.mp
@@ -6,7 +6,6 @@
 
 program parseError;
 
-
 const
   one = 1;
   two = 2;


### PR DESCRIPTION
Not really a ticket for this, but Jesse found that we were handling comments incorrectly. Basically every time we saw a `{` the scanner added a "RUN COMMENT ERROR" if it was in comment mode. This is totally legal though. A "RUN COMMENT ERROR" is when we're in a comment and see the end of file.
