### PR TITLE
Printing rule number, the lamest way to print

### DIFF
--- a/parser.cs
+++ b/parser.cs
@@ -60,7 +60,7 @@ public class Parser {
     // Match
     private void match(TOKENS token){
         // Simple output
-        Console.WriteLine("Matching " + __lookahead.Lexeme);
+        Console.WriteLine("\nMatching " + __lookahead.Lexeme);
         if(token == TOKENS.EOF){
             return;
         } else if(__e.Current.Type == token){
@@ -80,10 +80,10 @@ public class Parser {
     private void systemGoal(){
         switch(__lookahead.Type){
             case TOKENS.PROGRAM:
-                // Rule 1
+                Console.Write(1 + " ");
                 program();
                 match(TOKENS.EOF);
-                Console.WriteLine("The input program parses!");
+                Console.WriteLine("\nThe input program parses!");
                 break;
             default:
                 error(new List<TOKENS>{TOKENS.PROGRAM});
@@ -94,7 +94,7 @@ public class Parser {
     private void program(){
         switch(__lookahead.Type){
             case TOKENS.PROGRAM:
-                // Rule 2
+                Console.Write(2 + " ");
                 programHeading();
                 match(TOKENS.SCOLON);
                 block();
@@ -109,7 +109,7 @@ public class Parser {
     private void programHeading(){
         switch(__lookahead.Type){
             case TOKENS.PROGRAM:
-                // Rule 3
+                Console.Write(3 + " ");
                 match(TOKENS.PROGRAM);
                 programIdentifier();
                 break;
@@ -125,7 +125,7 @@ public class Parser {
             case TOKENS.FUNCTION:
             case TOKENS.PROCEDURE:
             case TOKENS.VAR:
-                // Rule 4
+                Console.Write(4 + " ");
                 variableDeclarationPart();
                 procedureAndFunctionDeclarationPart();
                 statementPart();
@@ -140,7 +140,7 @@ public class Parser {
     private void variableDeclarationPart(){
         switch(__lookahead.Type){
             case TOKENS.VAR:
-                // Rule 5
+                Console.Write(5 + " ");
                 match(TOKENS.VAR);
                 variableDeclaration();
                 match(TOKENS.SCOLON);
@@ -149,7 +149,7 @@ public class Parser {
             case TOKENS.BEGIN:
             case TOKENS.FUNCTION:
             case TOKENS.PROCEDURE:
-                // Rule 6
+                Console.Write(6 + " ");
                 break;
             default:
                 error(new List<TOKENS>{TOKENS.VAR, TOKENS.BEGIN, TOKENS.FUNCTION,
@@ -161,13 +161,13 @@ public class Parser {
     private void variableDeclarationTail(){
         switch(__lookahead.Type){
             case TOKENS.IDENTIFIER:
-                // Rule 7
+                Console.Write(7 + " ");
                 variableDeclaration();
                 match(TOKENS.SCOLON);
                 variableDeclarationTail();
                 break;
             case TOKENS.PROCEDURE:
-                // Rule 8
+                Console.Write(8 + " ");
                 break;
             default:
                 error(new List<TOKENS>{TOKENS.IDENTIFIER, TOKENS.PROCEDURE});
@@ -178,7 +178,7 @@ public class Parser {
     private void variableDeclaration(){
         switch(__lookahead.Type){
             case TOKENS.IDENTIFIER:
-                // Rule 9
+                Console.Write(9 + " ");
                 identifierList();
                 match(TOKENS.COLON);
                 type();
@@ -192,19 +192,19 @@ public class Parser {
     private void type(){
         switch(__lookahead.Type){
             case TOKENS.INTEGER:
-                // Rule 10
+                Console.Write(10 + " ");
                 match(TOKENS.INTEGER);
                 break;
             case TOKENS.FLOAT:
-                // Rule 11
+                Console.Write(11 + " ");
                 match(TOKENS.FLOAT);
                 break;
             case TOKENS.STRING:
-                // Rule 12
+                Console.Write(12 + " ");
                 match(TOKENS.STRING);
                 break;
             case TOKENS.BOOLEAN:
-                // Rule 13
+                Console.Write(13 + " ");
                 match(TOKENS.BOOLEAN);
                 break;
             default:
@@ -217,17 +217,17 @@ public class Parser {
     private void procedureAndFunctionDeclarationPart(){
         switch(__lookahead.Type){
             case TOKENS.PROCEDURE:
-                // Rule 14
+                Console.Write(14 + " ");
                 procedureDeclaration();
                 procedureAndFunctionDeclarationPart();
                 break;
             case TOKENS.FUNCTION:
-                // Rule 15
+                Console.Write(15 + " ");
                 functionDeclaration();
                 procedureAndFunctionDeclarationPart();
                 break;
             case TOKENS.BEGIN:
-                // Rule 16
+                Console.Write(16 + " ");
                 break;
             default:
                 error(new List<TOKENS>{TOKENS.PROCEDURE, TOKENS.FUNCTION, TOKENS.BEGIN});
@@ -238,7 +238,7 @@ public class Parser {
     private void procedureDeclaration(){
         switch(__lookahead.Type){
             case TOKENS.PROCEDURE:
-                // Rule 17
+                Console.Write(17 + " ");
                 procedureHeading();
                 match(TOKENS.SCOLON);
                 block();
@@ -253,7 +253,7 @@ public class Parser {
     private void functionDeclaration(){
         switch(__lookahead.Type){
             case TOKENS.FUNCTION:
-                // Rule 18
+                Console.Write(18 + " ");
                 functionHeading();
                 match(TOKENS.SCOLON);
                 block();
@@ -268,7 +268,7 @@ public class Parser {
     private void procedureHeading(){
         switch(__lookahead.Type){
             case TOKENS.PROCEDURE:
-                // Rule 19
+                Console.Write(19 + " ");
                 match(TOKENS.PROCEDURE);
                 procedureIdentifier();
                 optionalFormalParameterList();
@@ -282,7 +282,7 @@ public class Parser {
     private void functionHeading(){
         switch(__lookahead.Type){
             case TOKENS.FUNCTION:
-                // Rule 20
+                Console.Write(20 + " ");
                 match(TOKENS.FUNCTION);
                 functionIdentifier();
                 optionalFormalParameterList();
@@ -298,7 +298,7 @@ public class Parser {
     private void optionalFormalParameterList(){
         switch(__lookahead.Type){
             case TOKENS.LPAREN:
-                // Rule 21
+                Console.Write(21 + " ");
                 match(TOKENS.LPAREN);
                 formalParameterSection();
                 formalParameterSectionTail();
@@ -306,7 +306,7 @@ public class Parser {
                 break;
             case TOKENS.COLON:
             case TOKENS.SCOLON:
-                // Rule 22
+                Console.Write(22 + " ");
                 break;
             default:
                 error(new List<TOKENS>{TOKENS.LPAREN, TOKENS.COLON, TOKENS.SCOLON});
@@ -317,13 +317,13 @@ public class Parser {
     private void formalParameterSectionTail(){
         switch(__lookahead.Type){
             case TOKENS.SCOLON:
-                // Rule 23
+                Console.Write(23 + " ");
                 match(TOKENS.SCOLON);
                 formalParameterSection();
                 formalParameterSectionTail();
                 break;
             case TOKENS.RPAREN:
-                // Rule 24
+                Console.Write(24 + " ");
                 break;
             default:
                 error(new List<TOKENS>{TOKENS.SCOLON, TOKENS.RPAREN});
@@ -334,11 +334,11 @@ public class Parser {
     private void formalParameterSection(){
         switch(__lookahead.Type){
             case TOKENS.IDENTIFIER:
-                // Rule 25
+                Console.Write(25 + " ");
                 valueParameterSection();
                 break;
             case TOKENS.VAR:
-                // Rule 26
+                Console.Write(26 + " ");
                 variableParameterSection();
                 break;
             default:
@@ -350,7 +350,7 @@ public class Parser {
     private void valueParameterSection(){
         switch(__lookahead.Type){
             case TOKENS.IDENTIFIER:
-                // Rule 27
+                Console.Write(27 + " ");
                 identifierList();
                 match(TOKENS.COLON);
                 type();
@@ -364,7 +364,7 @@ public class Parser {
     private void variableParameterSection(){
         switch(__lookahead.Type){
             case TOKENS.VAR:
-                // Rule 28
+                Console.Write(28 + " ");
                 match(TOKENS.VAR);
                 identifierList();
                 match(TOKENS.COLON);
@@ -379,7 +379,7 @@ public class Parser {
     private void statementPart(){
         switch(__lookahead.Type){
             case TOKENS.BEGIN:
-                // Rule 29
+                Console.Write(29 + " ");
                 compoundStatement();
                 break;
             default:
@@ -391,7 +391,7 @@ public class Parser {
     private void compoundStatement(){
         switch(__lookahead.Type){
             case TOKENS.BEGIN:
-                // Rule 30
+                Console.Write(30 + " ");
                 match(TOKENS.BEGIN);
                 statementSequence();
                 match(TOKENS.END);
@@ -415,7 +415,7 @@ public class Parser {
             case TOKENS.WRITELN:
             case TOKENS.IDENTIFIER:
             case TOKENS.SCOLON:
-                // Rule 31
+                Console.Write(31 + " ");
                 statement();
                 statementTail();
                 break;
@@ -430,10 +430,10 @@ public class Parser {
     private void statementTail(){
         switch(__lookahead.Type) {
             case TOKENS.END:
-                // Rule 33
+                Console.Write(33 + " ");
                 break;
             case TOKENS.SCOLON:
-                // Rule 32
+                Console.Write(32 + " ");
                 match(TOKENS.SCOLON);
                 statement();
                 statementTail();
@@ -447,43 +447,43 @@ public class Parser {
     private void statement(){
         switch(__lookahead.Type) {
             case TOKENS.BEGIN:
-                // Rule 35
+                Console.Write(35 + " ");
                 compoundStatement();
                 break;
             case TOKENS.FOR:
-                // Rule 42
+                Console.Write(42 + " ");
                 forStatement();
                 break;
             case TOKENS.IF:
-                // Rule 39
+                Console.Write(39 + " ");
                 ifStatement();
                 break;
             case TOKENS.READ:
-                // Rule 36
+                Console.Write(36 + " ");
                 readStatement();
                 break;
             case TOKENS.REPEAT:
-                // Rule 41
+                Console.Write(41 + " ");
                 repeatStatement();
                 break;
             case TOKENS.WHILE:
-                // Rule 40
+                Console.Write(40 + " ");
                 whileStatement();
                 break;
             case TOKENS.WRITE:
             case TOKENS.WRITELN:
-                // Rule 37
+                Console.Write(37 + " ");
                 writeStatement();
                 break;
             case TOKENS.IDENTIFIER:
-                // Rule 38
+                Console.Write(38 + " ");
                 assignmentStatement();
-                // Rule 43
+                Console.Write(43 + " ");
                 // OR procedureStatement();
                 break;
             case TOKENS.END:
             case TOKENS.SCOLON:
-                // Rule 34
+                Console.Write(34 + " ");
                 emptyStatement();
                 break;
             default:
@@ -498,7 +498,7 @@ public class Parser {
         switch(__lookahead.Type) {
             case TOKENS.END:
             case TOKENS.SCOLON:
-                // Rule 44
+                Console.Write(44 + " ");
                 break;
             default:
                 error(new List<TOKENS>{TOKENS.END, TOKENS.SCOLON});
@@ -509,7 +509,7 @@ public class Parser {
     private void readStatement(){
         switch(__lookahead.Type) {
             case TOKENS.READ:
-                // Rule 45
+                Console.Write(45 + " ");
                 match(TOKENS.READ);
                 match(TOKENS.LPAREN);
                 readParameter();
@@ -525,13 +525,13 @@ public class Parser {
     private void readParameterTail(){
         switch(__lookahead.Type) {
             case TOKENS.COMMA:
-                // Rule 46
+                Console.Write(46 + " ");
                 match(TOKENS.COMMA);
                 readParameter();
                 readParameterTail();
                 break;
             case TOKENS.RPAREN:
-                // Rule 47
+                Console.Write(47 + " ");
                 break;
             default:
                 error(new List<TOKENS>{TOKENS.COMMA, TOKENS.RPAREN});
@@ -542,7 +542,7 @@ public class Parser {
     private void readParameter(){
         switch(__lookahead.Type) {
             case TOKENS.IDENTIFIER:
-                // Rule 48
+                Console.Write(48 + " ");
                 variableIdentifier();
                 break;
             default:
@@ -554,7 +554,7 @@ public class Parser {
     private void writeStatement(){
         switch(__lookahead.Type) {
             case TOKENS.WRITE:
-                // Rule 49
+                Console.Write(49 + " ");
                 match(TOKENS.WRITE);
                 match(TOKENS.LPAREN);
                 writeParameter();
@@ -562,7 +562,7 @@ public class Parser {
                 match(TOKENS.RPAREN);
                 break;
             case TOKENS.WRITELN:
-                // Rule 50
+                Console.Write(50 + " ");
                 match(TOKENS.WRITELN);
                 match(TOKENS.LPAREN);
                 writeParameter();
@@ -578,13 +578,13 @@ public class Parser {
     private void writeParameterTail(){
         switch(__lookahead.Type) {
             case TOKENS.COMMA:
-                // Rule 51
+                Console.Write(51 + " ");
                 match(TOKENS.COMMA);
                 writeParameter();
                 writeParameterTail();
                 break;
             case TOKENS.RPAREN:
-                // Rule 52
+                Console.Write(52 + " ");
                 break;
             default:
                 error(new List<TOKENS>{TOKENS.COMMA, TOKENS.RPAREN});
@@ -605,7 +605,7 @@ public class Parser {
             case TOKENS.LPAREN:
             case TOKENS.MINUS:
             case TOKENS.PLUS:
-                // Rule 53
+                Console.Write(53 + " ");
                 ordinalExpression();
                 break;
             default:
@@ -619,9 +619,9 @@ public class Parser {
     private void assignmentStatement(){
         switch(__lookahead.Type) {
             case TOKENS.IDENTIFIER:
-                // Rule 54
+                Console.Write(54 + " ");
                 variableIdentifier();
-                // Rule 55
+                Console.Write(55 + " ");
                 // OR functionIdentifier();
                 match(TOKENS.ASSIGN);
                 expression();
@@ -635,7 +635,7 @@ public class Parser {
     private void ifStatement(){
         switch(__lookahead.Type) {
             case TOKENS.IF:
-                // Rule 56
+                Console.Write(56 + " ");
                 match(TOKENS.IF);
                 booleanExpression();
                 match(TOKENS.THEN);
@@ -651,13 +651,13 @@ public class Parser {
     private void optionalElsePart(){
         switch(__lookahead.Type) {
             case TOKENS.ELSE:
-                // Rule 57
+                Console.Write(57 + " ");
                 match(TOKENS.ELSE);
                 statement();
                 break;
             case TOKENS.END:
             case TOKENS.SCOLON:
-                // Rule 58
+                Console.Write(58 + " ");
                 break;
             default:
                 error(new List<TOKENS>{TOKENS.ELSE, TOKENS.END, TOKENS.SCOLON});
@@ -668,7 +668,7 @@ public class Parser {
     private void repeatStatement(){
         switch(__lookahead.Type) {
             case TOKENS.REPEAT:
-                // Rule 59
+                Console.Write(59 + " ");
                 match(TOKENS.REPEAT);
                 statementSequence();
                 match(TOKENS.UNTIL);
@@ -683,7 +683,7 @@ public class Parser {
     private void whileStatement(){
         switch(__lookahead.Type) {
             case TOKENS.WHILE:
-                // Rule 60
+                Console.Write(60 + " ");
                 match(TOKENS.WHILE);
                 booleanExpression();
                 match(TOKENS.DO);
@@ -698,7 +698,7 @@ public class Parser {
     private void forStatement(){
         switch(__lookahead.Type) {
             case TOKENS.FOR:
-                // Rule 61
+                Console.Write(61 + " ");
                 match(TOKENS.FOR);
                 controlVariable();
                 match(TOKENS.ASSIGN);
@@ -717,7 +717,7 @@ public class Parser {
     private void controlVariable(){
         switch(__lookahead.Type) {
             case TOKENS.IDENTIFIER:
-                // Rule 62
+                Console.Write(62 + " ");
                 variableIdentifier();
                 break;
             default:
@@ -739,7 +739,7 @@ public class Parser {
             case TOKENS.LPAREN:
             case TOKENS.MINUS:
             case TOKENS.PLUS:
-                // Rule 63
+                Console.Write(63 + " ");
                 ordinalExpression();
                 break;
             default:
@@ -753,11 +753,11 @@ public class Parser {
     private void stepValue(){
         switch(__lookahead.Type) {
             case TOKENS.DOWNTO:
-                // Rule 65
+                Console.Write(65 + " ");
                 match(TOKENS.DOWNTO);
                 break;
             case TOKENS.TO:
-                // Rule 64
+                Console.Write(64 + " ");
                 match(TOKENS.TO);
                 break;
             default:
@@ -779,7 +779,7 @@ public class Parser {
             case TOKENS.LPAREN:
             case TOKENS.MINUS:
             case TOKENS.PLUS:
-                // Rule 66
+                Console.Write(66 + " ");
                 ordinalExpression();
                 break;
             default:
@@ -793,7 +793,7 @@ public class Parser {
     private void procedureStatement(){
         switch(__lookahead.Type) {
             case TOKENS.IDENTIFIER:
-                // Rule 67
+                Console.Write(67 + " ");
                 procedureIdentifier();
                 optionalActualParameterList();
                 break;
@@ -828,10 +828,10 @@ public class Parser {
             case TOKENS.RPAREN:
             case TOKENS.SCOLON:
             case TOKENS.TIMES:
-                // Rule 69
+                Console.Write(69 + " ");
                 break;
             case TOKENS.LPAREN:
-                // Rule 68
+                Console.Write(68 + " ");
                 match(TOKENS.LPAREN);
                 actualParameter();
                 actualParameterTail();
@@ -850,13 +850,13 @@ public class Parser {
     private void actualParameterTail(){
         switch(__lookahead.Type){
             case TOKENS.COMMA:
-                // Rule 70
+                Console.Write(70 + " ");
                 match(TOKENS.COMMA);
                 actualParameter();
                 actualParameterTail();
                 break;
             case TOKENS.RPAREN:
-                // Rule 71
+                Console.Write(71 + " ");
                 break;
             default:
                 error(new List<TOKENS>{TOKENS.COMMA, TOKENS.RPAREN});
@@ -877,7 +877,7 @@ public class Parser {
             case TOKENS.LPAREN:
             case TOKENS.MINUS:
             case TOKENS.PLUS:
-                // Rule 72
+                Console.Write(72 + " ");
                 ordinalExpression();
                 break;
             default:
@@ -901,7 +901,7 @@ public class Parser {
             case TOKENS.LPAREN:
             case TOKENS.MINUS:
             case TOKENS.PLUS:
-                // Rule 73
+                Console.Write(73 + " ");
                 simpleExpression();
                 optionalRelationalPart();
                 break;
@@ -923,7 +923,7 @@ public class Parser {
             case TOKENS.COMMA:
             case TOKENS.RPAREN:
             case TOKENS.SCOLON:
-                // Rule 75
+                Console.Write(75 + " ");
                 break;
             case TOKENS.EQUAL:
             case TOKENS.GEQUAL:
@@ -931,7 +931,7 @@ public class Parser {
             case TOKENS.LEQUAL:
             case TOKENS.LTHAN:
             case TOKENS.NEQUAL:
-                // Rule 74
+                Console.Write(74 + " ");
                 relationalOperator();
                 simpleExpression();
                 break;
@@ -946,27 +946,27 @@ public class Parser {
     private void relationalOperator(){
         switch(__lookahead.Type){
             case TOKENS.EQUAL:
-                // Rule 76
+                Console.Write(76 + " ");
                 match(TOKENS.EQUAL);
                 break;
             case TOKENS.LTHAN:
-                // Rule 77
+                Console.Write(77 + " ");
                 match(TOKENS.LTHAN);
                 break;
             case TOKENS.GTHAN:
-                // Rule 78
+                Console.Write(78 + " ");
                 match(TOKENS.GTHAN);
                 break;
             case TOKENS.LEQUAL:
-                // Rule 79
+                Console.Write(79 + " ");
                 match(TOKENS.LEQUAL);
                 break;
             case TOKENS.GEQUAL:
-                // Rule 80
+                Console.Write(80 + " ");
                 match(TOKENS.GEQUAL);
                 break;
             case TOKENS.NEQUAL:
-                // Rule 81
+                Console.Write(81 + " ");
                 match(TOKENS.NEQUAL);
                 break;
             default:
@@ -989,7 +989,7 @@ public class Parser {
             case TOKENS.LPAREN:
             case TOKENS.MINUS:
             case TOKENS.PLUS:
-                // Rule 82
+                Console.Write(82 + " ");
                 optionalSign();
                 term();
                 termTail();
@@ -1018,12 +1018,12 @@ public class Parser {
             case TOKENS.NEQUAL:
             case TOKENS.RPAREN:
             case TOKENS.SCOLON:
-                // Rule 84
+                Console.Write(84 + " ");
                 break;
             case TOKENS.OR:
             case TOKENS.MINUS:
             case TOKENS.PLUS:
-                // Rule 83
+                Console.Write(83 + " ");
                 addingOperator();
                 term();
                 termTail();
@@ -1048,14 +1048,14 @@ public class Parser {
             case TOKENS.FLOAT_LIT:
             case TOKENS.STRING_LIT:
             case TOKENS.LPAREN:
-                // Rule 87
+                Console.Write(87 + " ");
                 break;
             case TOKENS.MINUS:
-                // Rule 86
+                Console.Write(86 + " ");
                 match(TOKENS.MINUS);
                 break;
             case TOKENS.PLUS:
-                // Rule 85
+                Console.Write(85 + " ");
                 match(TOKENS.PLUS);
                 break;
             default:
@@ -1069,15 +1069,15 @@ public class Parser {
     private void addingOperator(){
         switch(__lookahead.Type){
             case TOKENS.OR:
-                // Rule 90
+                Console.Write(90 + " ");
                 match(TOKENS.OR);
                 break;
             case TOKENS.MINUS:
-                // Rule 89
+                Console.Write(89 + " ");
                 match(TOKENS.MINUS);
                 break;
             case TOKENS.PLUS:
-                // Rule 88
+                Console.Write(88 + " ");
                 match(TOKENS.PLUS);
                 break;
             default:
@@ -1097,7 +1097,7 @@ public class Parser {
             case TOKENS.FLOAT_LIT:
             case TOKENS.STRING_LIT:
             case TOKENS.LPAREN:
-                // Rule 91
+                Console.Write(91 + " ");
                 factor();
                 factorTail();
                 break;
@@ -1116,7 +1116,7 @@ public class Parser {
             case TOKENS.MOD:
             case TOKENS.FLOAT_DIVIDE:
             case TOKENS.TIMES:
-                // Rule 92
+                Console.Write(92 + " ");
                 multiplyingOperator();
                 factor();
                 factorTail();
@@ -1138,7 +1138,7 @@ public class Parser {
             case TOKENS.PLUS:
             case TOKENS.RPAREN:
             case TOKENS.SCOLON:
-                // Rule 93
+                Console.Write(93 + " ");
                 break;
             default:
                 error(new List<TOKENS>{TOKENS.AND, TOKENS.DIV, TOKENS.MOD, TOKENS.FLOAT_DIVIDE,
@@ -1153,11 +1153,11 @@ public class Parser {
     private void multiplyingOperator(){
         switch(__lookahead.Type){
             case TOKENS.AND:
-                // Rule 98
+                Console.Write(98 + " ");
                 match(TOKENS.AND);
                 break;
             case TOKENS.DIV:
-                // Rule 96
+                Console.Write(96 + " ");
                 match(TOKENS.DIV);
                 break;
             case TOKENS.MOD:
@@ -1165,11 +1165,11 @@ public class Parser {
                 match(TOKENS.MOD);
                 break;
             case TOKENS.FLOAT_DIVIDE:
-                // Rule 95
+                Console.Write(95 + " ");
                 match(TOKENS.FLOAT_DIVIDE);
                 break;
             case TOKENS.TIMES:
-                // Rule 94
+                Console.Write(94 + " ");
                 match(TOKENS.TIMES);
                 break;
             default:
@@ -1182,41 +1182,41 @@ public class Parser {
     private void factor(){
         switch(__lookahead.Type){
             case TOKENS.FALSE:
-                // Rule 103
+                Console.Write(103 + " ");
                 match(TOKENS.FALSE);
                 break;
             case TOKENS.NOT:
-                // Rule 104
+                Console.Write(104 + " ");
                 match(TOKENS.NOT);
                 factor();
                 break;
             case TOKENS.TRUE:
-                // Rule 102
+                Console.Write(102 + " ");
                 match(TOKENS.TRUE);
                 break;
             case TOKENS.IDENTIFIER:
-                // Rule 106
+                Console.Write(106 + " ");
                 functionIdentifier();
                 optionalActualParameterList();
                 break;
             case TOKENS.INTEGER_LIT:
-                // Rule 99
+                Console.Write(99 + " ");
                 match(TOKENS.INTEGER_LIT);
                 break;
             case TOKENS.FIXED_LIT:
-                // Rule 100?
+                Console.Write(100 + " ");
                 match(TOKENS.FIXED_LIT);
                 break;
             case TOKENS.FLOAT_LIT:
-                // Rule 100
+                Console.Write(100 + " ");
                 match(TOKENS.FLOAT_LIT);
                 break;
             case TOKENS.STRING_LIT:
-                // Rule 101
+                Console.Write(101 + " ");
                 match(TOKENS.STRING_LIT);
                 break;
             case TOKENS.LPAREN:
-                // Rule 105
+                Console.Write(105 + " ");
                 match(TOKENS.LPAREN);
                 expression();
                 match(TOKENS.RPAREN);
@@ -1232,7 +1232,7 @@ public class Parser {
     private void programIdentifier(){
         switch(__lookahead.Type){
             case TOKENS.IDENTIFIER:
-                // Rule 107
+                Console.Write(107 + " ");
                 match(TOKENS.IDENTIFIER);
                 break;
             default:
@@ -1244,7 +1244,7 @@ public class Parser {
     private void variableIdentifier(){
         switch(__lookahead.Type){
             case TOKENS.IDENTIFIER:
-                // Rule 108
+                Console.Write(108 + " ");
                 match(TOKENS.IDENTIFIER);
                 break;
             default:
@@ -1256,7 +1256,7 @@ public class Parser {
     private void procedureIdentifier(){
         switch(__lookahead.Type){
             case TOKENS.IDENTIFIER:
-                // Rule 109
+                Console.Write(109 + " ");
                 match(TOKENS.IDENTIFIER);
                 break;
             default:
@@ -1268,7 +1268,7 @@ public class Parser {
     private void functionIdentifier(){
         switch(__lookahead.Type){
             case TOKENS.IDENTIFIER:
-                // Rule 110
+                Console.Write(110 + " ");
                 match(TOKENS.IDENTIFIER);
                 break;
             default:
@@ -1287,7 +1287,7 @@ public class Parser {
             case TOKENS.FLOAT_LIT:
             case TOKENS.STRING_LIT:
             case TOKENS.LPAREN:
-                // Rule 111
+                Console.Write(111 + " ");
                 expression();
                 break;
             default:
@@ -1308,7 +1308,7 @@ public class Parser {
             case TOKENS.FLOAT_LIT:
             case TOKENS.STRING_LIT:
             case TOKENS.LPAREN:
-                // Rule 112
+                Console.Write(112 + " ");
                 expression();
                 break;
             default:
@@ -1322,7 +1322,7 @@ public class Parser {
     private void identifierList(){
         switch(__lookahead.Type){
             case TOKENS.IDENTIFIER:
-                // Rule 113
+                Console.Write(113 + " ");
                 match(TOKENS.IDENTIFIER);
                 identifierTail();
                 break;
@@ -1335,10 +1335,10 @@ public class Parser {
     private void identifierTail(){
         switch(__lookahead.Type){
             case TOKENS.COLON:
-                // Rule 115
+                Console.Write(115 + " ");
                 break;
             case TOKENS.COMMA:
-                // Rule 114
+                Console.Write(114 + " ");
                 match(TOKENS.COMMA);
                 match(TOKENS.IDENTIFIER);
                 identifierTail();


### PR DESCRIPTION
So this handles just printing the rule numbers as we follow the rules, which Rocky had as a minimum for printing the parse tree. In developing the actual parse tree implementation (with PNG output!!!), I realized it would only make sense with a full refactor of the parser. So I'm including this minimum version so that we can tag it, and keeping the parseTree print in the backlog that I will keep working on.
