### PR TITLE
For loop fixer upper

### DIFF
--- a/SemAnalyzer.cs
+++ b/SemAnalyzer.cs
@@ -45,6 +45,11 @@ public class SemAnalyzer{
         output("POP D" + size);
     }
 
+    public void genPopFinalValue(){
+        SymbolTable top = SymbolTableStack.Peek();
+        output("POP " + top.Size + "(D" + top.NestingLevel + ")");
+    }
+
     public void genPushCurrentNestingLevel(){
         SymbolTable top = SymbolTableStack.Peek();
         output("PUSH D" + top.NestingLevel);

--- a/SymbolTable.cs
+++ b/SymbolTable.cs
@@ -62,6 +62,12 @@ public class SymbolTable {
         }
     }
 
+    public void RemoveEntry(Entry entryRemoving){
+        if(!Entries.Remove(entryRemoving)){
+            throw new Exception("Tried to remove an entry for the symbol table that was not in the symbol table");
+        }
+    }
+
     public int GetSize(){
         int totalSize = 0;
         foreach(Entry entry in Entries){

--- a/SymbolTable.cs
+++ b/SymbolTable.cs
@@ -66,6 +66,7 @@ public class SymbolTable {
         if(!Entries.Remove(entryRemoving)){
             throw new Exception("Tried to remove an entry for the symbol table that was not in the symbol table");
         }
+        DecSize();
     }
 
     public int GetSize(){

--- a/parser.cs
+++ b/parser.cs
@@ -981,8 +981,9 @@ public class Parser {
                 // Generate the starting label
                 __analyzer.genOut(start + ":");
 
+                __analyzer.genPushVar(finalVar);
                 __analyzer.genPushVar(controlVar);
-                __analyzer.genPushVar(finalVal);
+
 
                 // Generate either CMPGES or CMPLES depending on what was chosen
                 // (either to or downto).

--- a/parser.cs
+++ b/parser.cs
@@ -957,25 +957,32 @@ public class Parser {
                 Entry variable = __symbolTableStack.Peek().GetEntry(controlVar.Lexeme);
                 variable.Modifiable = false;
 
-                // Generate the starting label
-                __analyzer.genOut(start + ":");
-
                 // Retrieve the semrecord for what type of for loop
                 // (to or downto). Note: this will return either a 1 or -1
                 // for adding later.
                 SemRecord step = stepValue();
 
+
+                __analyzer.genSymSize(1);
                 // Retrieve finalValue semrec and generate the push the initial
                 // (now controlVariable) and the finalValue on the stack for it.
                 SemRecord finalVal = finalValue();
+                SemRecord finalVar = new SemRecord(finalVal.Type, "finalVal" + start);
 
-                Entry finalValEntry = __symbolTableStack.Peek().GetEntry(finalVal.Lexeme);
+                __symbolTableStack.Peek().AddEntry(finalVar.Lexeme, finalVar.Type, KINDS.VAR, 1, null);
+                Entry finalValEntry = __symbolTableStack.Peek().GetEntry(finalVar.Lexeme);
+
+                __analyzer.genAssign(finalVar, finalVal);
 
                 if(finalValEntry != null) {
                     finalValEntry.Modifiable = false;
                 }
 
+                // Generate the starting label
+                __analyzer.genOut(start + ":");
+
                 __analyzer.genPushVar(controlVar);
+                __analyzer.genPushVar(finalVal);
 
                 // Generate either CMPGES or CMPLES depending on what was chosen
                 // (either to or downto).
@@ -1010,6 +1017,8 @@ public class Parser {
                     finalValEntry.Modifiable = true;
                 }
                 __analyzer.genOut(end + ":");
+                __symbolTableStack.Peek().RemoveEntry(finalValEntry);
+                __analyzer.genSymSize(-1);
                 break;
             default:
                 error(new List<TOKENS>{TOKENS.FOR});


### PR DESCRIPTION
Ok lads, I think this will fix for loops. I have not had the chance to test it on nested for loops, however. I think it will work. It works by adding a temporary entry to the current symbol table that holds the value of the final value, whether that is an expression or a variable. It then uses that final value for all the tests. This means we can modify the variable originally used as the final value, because modifying it does not change the temporary entrie's value. Then we remove the entry at the end of the loop and clean up.
